### PR TITLE
feat(server): add user registration service

### DIFF
--- a/server/app/controllers/api/registrations_controller.rb
+++ b/server/app/controllers/api/registrations_controller.rb
@@ -1,0 +1,17 @@
+class Api::RegistrationsController < ApplicationController
+  def create
+    user = User.create!(user_params)
+
+    render json: {
+      status: "success",
+      message: "Usuario registrado. Revisa tu email para validar la cuenta.",
+      data: { email: user.email }
+    }, status: :created
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:email, :password, :nickname)
+  end
+end

--- a/server/app/controllers/application_controller.rb
+++ b/server/app/controllers/application_controller.rb
@@ -1,2 +1,19 @@
 class ApplicationController < ActionController::API
+  rescue_from ActionController::ParameterMissing, with: :bad_request_response
+  rescue_from ActiveRecord::RecordInvalid, with: :unprocessable_entity_response
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_response
+
+  private
+
+  def bad_request_response(exception)
+    render json: { error: exception }, status: :bad_request
+  end
+
+  def unprocessable_entity_response(exception)
+    render json: { errors: exception.record.errors.full_messages }, status: :unprocessable_entity
+  end
+
+  def not_found_response(exception)
+    render json: { error: exception.message }, status: :not_found
+  end
 end

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -7,4 +7,7 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "posts#index"
+  namespace :api do
+    post "signup", to: "registrations#create"
+  end
 end


### PR DESCRIPTION
Added route `/api/signup` for user registrations.

It expect a **user** key in json root level which will contain: **email, nickname and password**.

The model will do the validations and the rescue_from in the application controller will send the formatted response.
400
![image](https://github.com/user-attachments/assets/b4f82f24-041b-4c1f-9eb1-cf65559945e4)
![image](https://github.com/user-attachments/assets/ae84f77d-6cf5-472b-9fcb-5f990b179817)
422
![image](https://github.com/user-attachments/assets/c17337af-7e9e-4e88-be38-3b1bfe845197)

201
![image](https://github.com/user-attachments/assets/e5e1aad2-d62f-403c-95aa-ec99dd1a8a30)
user created in db:
![image](https://github.com/user-attachments/assets/9e6a2ff3-25f8-4fb1-b52f-71ab53645b5b)
