### PR TITLE
feat(server): add message model

### DIFF
--- a/server/app/models/channel.rb
+++ b/server/app/models/channel.rb
@@ -1,6 +1,8 @@
 class Channel < ApplicationRecord
   belongs_to :creator, class_name: "User"
 
+  has_many :messages, dependent: :destroy
+
   validates :name,
     presence: true,
     uniqueness: true,

--- a/server/app/models/message.rb
+++ b/server/app/models/message.rb
@@ -1,0 +1,45 @@
+class Message < ApplicationRecord
+  belongs_to :sender, class_name: "User"
+  belongs_to :receiver, class_name: "User", optional: true
+  belongs_to :channel, optional: true
+
+  validates :content, presence: true,
+                      format: { with: /\A\S+.*\z/, message: "it cannot be black or just spaces" },
+                      length: { maximum: 1000, message: "1000 characters max" },
+                      format: { without: /<[^>]*>/, message: "HTML is not supported" }
+
+  validate :channel_xor_receiver_presence
+  validates :receiver, presence: { message: "must exist" }, if: -> { receiver_id.present? }
+  validates :channel, presence: { message: "must exist" }, if: -> { channel_id.present? }
+
+  validate :prevent_self_messaging
+
+  scope :between_users, ->(user1, user2, options = {}) {
+    order = options.fetch(:order, :desc)
+    where(sender: user1, receiver: user2)
+      .or(where(sender: user2, receiver: user1))
+      .order(created_at: order)
+  }
+
+  private
+
+  def direct_message?
+    receiver.present? && channel.blank?
+  end
+
+  def prevent_self_messaging
+    return unless direct_message?
+
+    if sender == receiver
+      errors.add(:receiver_id, "You cannot send direct messages to yourself.")
+    end
+  end
+
+  def channel_xor_receiver_presence
+    if channel.blank? && receiver.blank?
+      errors.add(:base, "The message have to be for a channel or a user")
+    elsif channel.present? && receiver.present?
+      errors.add(:base, "The message cannot be for a channel and a user at the same time")
+    end
+  end
+end

--- a/server/app/models/user.rb
+++ b/server/app/models/user.rb
@@ -6,6 +6,16 @@ class User < ApplicationRecord
     foreign_key: "creator_id",
     dependent: :destroy
 
+  has_many :sent_messages,
+    class_name: "Message",
+    foreign_key: "sender_id",
+    dependent: :destroy
+
+  has_many :received_messages,
+    class_name: "Message",
+    foreign_key: "receiver_id",
+    dependent: :destroy
+
   validates :email,
     presence: true,
     uniqueness: true,

--- a/server/db/migrate/20250314182105_create_messages.rb
+++ b/server/db/migrate/20250314182105_create_messages.rb
@@ -1,0 +1,15 @@
+class CreateMessages < ActiveRecord::Migration[7.2]
+  def change
+    create_table :messages do |t|
+      t.text :content, null: false
+      t.references :sender, null: false, foreign_key: { to_table: :users }
+      t.references :receiver, foreign_key: { to_table: :users }
+      t.references :channel, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :messages, [ :sender_id, :receiver_id ], name: "index_messages_on_sender_and_receiver"
+    add_index :messages, [ :receiver_id, :sender_id ], name: "index_messages_on_receiver_and_sender"
+  end
+end

--- a/server/db/schema.rb
+++ b/server/db/schema.rb
@@ -29,7 +29,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_14_182105) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["channel_id"], name: "index_messages_on_channel_id"
+    t.index ["receiver_id", "sender_id"], name: "index_messages_on_receiver_and_sender"
     t.index ["receiver_id"], name: "index_messages_on_receiver_id"
+    t.index ["sender_id", "receiver_id"], name: "index_messages_on_sender_and_receiver"
     t.index ["sender_id"], name: "index_messages_on_sender_id"
   end
 

--- a/server/db/schema.rb
+++ b/server/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_14_173048) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_14_182105) do
   create_table "channels", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "description"
@@ -19,6 +19,18 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_14_173048) do
     t.datetime "updated_at", null: false
     t.index ["creator_id"], name: "index_channels_on_creator_id"
     t.index ["name"], name: "index_channels_on_name", unique: true
+  end
+
+  create_table "messages", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.text "content", null: false
+    t.bigint "sender_id", null: false
+    t.bigint "receiver_id"
+    t.bigint "channel_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["channel_id"], name: "index_messages_on_channel_id"
+    t.index ["receiver_id"], name: "index_messages_on_receiver_id"
+    t.index ["sender_id"], name: "index_messages_on_sender_id"
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -33,4 +45,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_14_173048) do
   end
 
   add_foreign_key "channels", "users", column: "creator_id"
+  add_foreign_key "messages", "channels"
+  add_foreign_key "messages", "users", column: "receiver_id"
+  add_foreign_key "messages", "users", column: "sender_id"
 end


### PR DESCRIPTION
Added message model with validations.

Successful
![image](https://github.com/user-attachments/assets/c94276ca-7a84-4bff-aa9a-7daec8ea41fc)

retrieving conversation between users, it can be `asc or decs`
![image](https://github.com/user-attachments/assets/a22149ef-f3ac-4a10-b473-af3b47fd17b7)


receiver dont exist
![image](https://github.com/user-attachments/assets/37d8110a-fbe1-485c-8530-b58b8de32b5f)

Same sender and receiver user
![image](https://github.com/user-attachments/assets/1e61bc46-dce7-4022-be81-a8dc922e8498)

without receiver
![image](https://github.com/user-attachments/assets/a291790b-c687-44dc-ac95-bb03c236655e)

without sender
![image](https://github.com/user-attachments/assets/782213ef-79de-410e-b4be-03da9cae7d62)

sending HTML and more than  1000 chars
![image](https://github.com/user-attachments/assets/db95f1e2-e0b0-4fea-b5bd-843cae1179bb)
