### PR TITLE
refactor(server): Remove receiver from messages and enforce required channel

### DIFF
--- a/server/app/models/channel.rb
+++ b/server/app/models/channel.rb
@@ -2,14 +2,47 @@ class Channel < ApplicationRecord
   belongs_to :creator, class_name: "User"
 
   has_many :messages, dependent: :destroy
+  has_many :memberships, dependent: :destroy
+  has_many :users, through: :memberships
 
   validates :name,
     presence: true,
-    uniqueness: true,
+    uniqueness: {
+      case_sensitive: false,
+      scope: :public,
+      conditions: -> { where(public: true) }
+    },
     format: {
       with: /\A[\w-]+\z/,
       message: "just letters, numbers, scores and underscores allowed"
-    }
+    },
+    if: :public?
 
-  validates :description, length: { maximum: 500 }
+  validates :description, length: { maximum: 500 }, if: :public?
+  validate :private_channel_has_no_name, unless: :public?
+  validate :creator_must_be_confirmed
+
+  after_create :create_creator_membership
+
+  private
+
+  def create_creator_membership
+    memberships.create!(
+      user: creator,
+      role: :creator,
+      status: :active
+    )
+  end
+
+  def private_channel_has_no_name
+    return unless name.present?
+
+    errors.add(:name, "Private channels does not support names")
+  end
+
+  def creator_must_be_confirmed
+    return if creator&.confirmed?
+
+    errors.add(:creator, "must be confirmed to create a channel")
+  end
 end

--- a/server/app/models/membership.rb
+++ b/server/app/models/membership.rb
@@ -1,0 +1,16 @@
+class Membership < ApplicationRecord
+  belongs_to :user
+  belongs_to :channel
+
+  enum :role, { member: 0, creator: 1 }, default: :member
+  enum :status, { active: 0, banned: 1 }, default: :active
+
+  validates :user_id, uniqueness: { scope: :channel_id }
+  validate :user_must_be_confirmed
+
+  private
+
+  def user_must_be_confirmed
+    errors.add(:user, "must be confirmed") unless user.confirmed?
+  end
+end

--- a/server/app/models/message.rb
+++ b/server/app/models/message.rb
@@ -1,6 +1,5 @@
 class Message < ApplicationRecord
   belongs_to :sender, class_name: "User"
-  belongs_to :receiver, class_name: "User", optional: true
   belongs_to :channel, optional: true
 
   validates :content, presence: true,
@@ -8,38 +7,6 @@ class Message < ApplicationRecord
                       length: { maximum: 1000, message: "1000 characters max" },
                       format: { without: /<[^>]*>/, message: "HTML is not supported" }
 
-  validate :channel_xor_receiver_presence
-  validates :receiver, presence: { message: "must exist" }, if: -> { receiver_id.present? }
-  validates :channel, presence: { message: "must exist" }, if: -> { channel_id.present? }
-
-  validate :prevent_self_messaging
-
-  scope :between_users, ->(user1, user2, options = {}) {
-    order = options.fetch(:order, :desc)
-    where(sender: user1, receiver: user2)
-      .or(where(sender: user2, receiver: user1))
-      .order(created_at: order)
-  }
-
-  private
-
-  def direct_message?
-    receiver.present? && channel.blank?
-  end
-
-  def prevent_self_messaging
-    return unless direct_message?
-
-    if sender == receiver
-      errors.add(:receiver_id, "You cannot send direct messages to yourself.")
-    end
-  end
-
-  def channel_xor_receiver_presence
-    if channel.blank? && receiver.blank?
-      errors.add(:base, "The message have to be for a channel or a user")
-    elsif channel.present? && receiver.present?
-      errors.add(:base, "The message cannot be for a channel and a user at the same time")
-    end
-  end
+  validates :sender, presence: true
+  validates :channel, presence: true
 end

--- a/server/app/models/user.rb
+++ b/server/app/models/user.rb
@@ -6,16 +6,6 @@ class User < ApplicationRecord
     foreign_key: "creator_id",
     dependent: :destroy
 
-  has_many :sent_messages,
-    class_name: "Message",
-    foreign_key: "sender_id",
-    dependent: :destroy
-
-  has_many :received_messages,
-    class_name: "Message",
-    foreign_key: "receiver_id",
-    dependent: :destroy
-
   validates :email,
     presence: true,
     uniqueness: true,

--- a/server/db/migrate/20250314212846_create_memberships.rb
+++ b/server/db/migrate/20250314212846_create_memberships.rb
@@ -1,0 +1,15 @@
+class CreateMemberships < ActiveRecord::Migration[7.2]
+  def change
+    create_table :memberships do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :channel, null: false, foreign_key: true
+      t.integer :role, default: 0
+      t.integer :status, default: 0
+
+      t.timestamps
+    end
+
+    add_index :memberships, [ :user_id, :channel_id ], unique: true, name: 'index_memberships_on_user_and_channel'
+    add_index :memberships, :status
+  end
+end

--- a/server/db/migrate/20250314221404_cleanup_messages_schema.rb
+++ b/server/db/migrate/20250314221404_cleanup_messages_schema.rb
@@ -1,0 +1,12 @@
+class CleanupMessagesSchema < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :messages, name: "index_messages_on_sender_and_receiver"
+    remove_index :messages, name: "index_messages_on_receiver_and_sender"
+
+    remove_reference :messages, :receiver, foreign_key: { to_table: :users }
+
+    change_column_null :messages, :channel_id, false
+
+    add_index :messages, [ :sender_id, :channel_id ], name: "index_messages_on_sender_and_channel"
+  end
+end

--- a/server/db/migrate/20250314222120_add_type_to_channels.rb
+++ b/server/db/migrate/20250314222120_add_type_to_channels.rb
@@ -1,0 +1,7 @@
+class AddTypeToChannels < ActiveRecord::Migration[7.2]
+  def change
+    add_column :channels, :public, :boolean, default: true
+
+    change_column_null :channels, :name, true
+  end
+end

--- a/server/db/schema.rb
+++ b/server/db/schema.rb
@@ -10,28 +10,39 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_14_182105) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_14_222120) do
   create_table "channels", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "name", null: false
+    t.string "name"
     t.text "description"
     t.bigint "creator_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "public", default: true
     t.index ["creator_id"], name: "index_channels_on_creator_id"
     t.index ["name"], name: "index_channels_on_name", unique: true
+  end
+
+  create_table "memberships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "channel_id", null: false
+    t.integer "role", default: 0
+    t.integer "status", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["channel_id"], name: "index_memberships_on_channel_id"
+    t.index ["status"], name: "index_memberships_on_status"
+    t.index ["user_id", "channel_id"], name: "index_memberships_on_user_and_channel", unique: true
+    t.index ["user_id"], name: "index_memberships_on_user_id"
   end
 
   create_table "messages", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.text "content", null: false
     t.bigint "sender_id", null: false
-    t.bigint "receiver_id"
-    t.bigint "channel_id"
+    t.bigint "channel_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["channel_id"], name: "index_messages_on_channel_id"
-    t.index ["receiver_id", "sender_id"], name: "index_messages_on_receiver_and_sender"
-    t.index ["receiver_id"], name: "index_messages_on_receiver_id"
-    t.index ["sender_id", "receiver_id"], name: "index_messages_on_sender_and_receiver"
+    t.index ["sender_id", "channel_id"], name: "index_messages_on_sender_and_channel"
     t.index ["sender_id"], name: "index_messages_on_sender_id"
   end
 
@@ -47,7 +58,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_14_182105) do
   end
 
   add_foreign_key "channels", "users", column: "creator_id"
+  add_foreign_key "memberships", "channels"
+  add_foreign_key "memberships", "users"
   add_foreign_key "messages", "channels"
-  add_foreign_key "messages", "users", column: "receiver_id"
   add_foreign_key "messages", "users", column: "sender_id"
 end


### PR DESCRIPTION
Membership model added.


Now all messages are sent to a channel, the private channels will be 1:1 and will have chat history. Public chats for multiple users at a time, this wont retrieve chat history because it's not intended to.

![image](https://github.com/user-attachments/assets/e3b5a346-6e9e-4ebf-9964-dcc64325f50f)
